### PR TITLE
更新履歴の表示改善

### DIFF
--- a/models/index.ts
+++ b/models/index.ts
@@ -1,2 +1,2 @@
-export { Note, NoteComment } from './note'
+export { Note, NoteComment, NoteHistory } from './note'
 export { User, userConverter } from './user'

--- a/models/user.ts
+++ b/models/user.ts
@@ -24,6 +24,19 @@ export class User implements IUser {
       photoURL,
     })
   }
+
+  get name() {
+    return this.displayName
+  }
+
+  get photoProps() {
+    return {
+      width: 32,
+      height: 32,
+      class: 'm1',
+      src: this.photoURL,
+    }
+  }
 }
 
 export const userConverter = {

--- a/pages/notes/_id/diff/_history.vue
+++ b/pages/notes/_id/diff/_history.vue
@@ -2,7 +2,13 @@
   <b-container>
     <h1 class="text-center">ノート更新履歴</h1>
     <b-card>
-      <h5 class="text-muted">Content</h5>
+      <h5 class="text-muted">タイトル</h5>
+      <div v-for="(part, index) in diffTitle" :key="index">
+        <div :class="{ added: part.added, removed: part.removed }">
+          <div style="white-space: pre-line">{{ part.value }}</div>
+        </div>
+      </div>
+      <h5 class="text-muted">内容</h5>
       <div v-for="(part, index) in diffContent" :key="index">
         <div :class="{ added: part.added, removed: part.removed }">
           <div style="white-space: pre-line">{{ part.value }}</div>
@@ -15,28 +21,30 @@
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
 import { notesStore } from '@/store'
+import { Note, NoteHistory } from '@/models'
 const Diff = require('diff')
 
 @Component
 class NoteDiff extends Vue {
-  private prevNoteContent: string = ''
-  private currentNoteContent: string = ''
+  private note: Note = new Note({})
+  private history: NoteHistory = new NoteHistory({})
+
+  get diffTitle() {
+    return Diff.diffLines(this.history?.title, this.note?.title)
+  }
 
   get diffContent() {
-    return Diff.diffLines(this.prevNoteContent, this.currentNoteContent)
+    return Diff.diffLines(this.history?.content, this.note?.content)
   }
 
   async created() {
     const noteId = this.$route.params.id
     const historyId = this.$route.params.history
-    const note = await notesStore.getNote(noteId)
-    const history = await notesStore.getNoteHistory({
+    this.note = await notesStore.getNote(noteId)
+    this.history = await notesStore.getNoteHistory({
       id: noteId,
       historyId,
     })
-
-    this.prevNoteContent = history.content
-    this.currentNoteContent = note.content
   }
 }
 export default NoteDiff

--- a/pages/notes/_id/diff/_history.vue
+++ b/pages/notes/_id/diff/_history.vue
@@ -1,14 +1,28 @@
 <template>
   <b-container>
     <h1 class="text-center">ノート更新履歴</h1>
-    <b-card>
-      <h5 class="text-muted">タイトル</h5>
+    <div class="mb-3">
+      <div v-if="editor" class="d-flex justify-content-start">
+        <div class="history__avatar-cell">
+          <b-img v-bind="editor.photoProps" rounded="circle" />
+        </div>
+        <div>
+          <NuxtLink :to="{ path: `/users/${editor.id}` }">
+            {{ editor.name }}
+          </NuxtLink>
+          <br />
+          {{ history.createdAtString() }}
+        </div>
+      </div>
+    </div>
+    <b-card header="タイトルの変更" class="mb-3">
       <div v-for="(part, index) in diffTitle" :key="index">
         <div :class="{ added: part.added, removed: part.removed }">
           <div style="white-space: pre-line">{{ part.value }}</div>
         </div>
       </div>
-      <h5 class="text-muted">内容</h5>
+    </b-card>
+    <b-card header="内容の変更">
       <div v-for="(part, index) in diffContent" :key="index">
         <div :class="{ added: part.added, removed: part.removed }">
           <div style="white-space: pre-line">{{ part.value }}</div>
@@ -20,8 +34,8 @@
 
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
-import { notesStore } from '@/store'
-import { Note, NoteHistory } from '@/models'
+import { notesStore, usersStore } from '@/store'
+import { Note, NoteHistory, User } from '@/models'
 const Diff = require('diff')
 
 @Component
@@ -37,7 +51,13 @@ class NoteDiff extends Vue {
     return Diff.diffLines(this.history?.content, this.note?.content)
   }
 
+  get editor(): User | undefined {
+    return usersStore.users.find((user) => user.id === this.history.userId)
+  }
+
   async created() {
+    await usersStore.initialize()
+
     const noteId = this.$route.params.id
     const historyId = this.$route.params.history
     this.note = await notesStore.getNote(noteId)
@@ -56,5 +76,11 @@ export default NoteDiff
 }
 .removed {
   background-color: #ffdce0;
+}
+.history__avatar-cell {
+  width: 48px;
+  width: 48px;
+  padding: 8px;
+  vertical-align: center;
 }
 </style>

--- a/store/notes.ts
+++ b/store/notes.ts
@@ -153,11 +153,13 @@ class Notes extends VuexModule {
   async updateNote(note: Note) {
     const noteRef = this.notesRef.doc(note.id)
     const beforeNote = await noteRef.get()
+    const beforeTitle = beforeNote.get('title')
     const beforeContent = beforeNote.get('content')
 
-    // NOTE: 内容（content）に変更がないときは履歴に残さない
-    if (beforeContent !== note.content) {
+    // タイトルか内容に変更がないときは履歴に残さない
+    if (beforeTitle !== note.title || beforeContent !== note.content) {
       await noteRef.collection('histories').add({
+        title: beforeTitle,
         content: beforeContent,
         userId: authStore.userId,
         createdAt: FieldValue.serverTimestamp(),


### PR DESCRIPTION
- 更新者の情報を表示
- タイトルの差分も追えるように
- 見た目の修正

更新履歴の仕様について疑問。
最新のノートと選択した履歴の差分を取っているが、「履歴と、その次に更新したノートとの差分」のほうが使い勝手がよさそうにおもった。
10回更新した最新と、初回の差分にあまり意味はないなと。
